### PR TITLE
update network dep to be zig 0.9 compat

### DIFF
--- a/gyro.zzz
+++ b/gyro.zzz
@@ -10,7 +10,11 @@ pkgs:
       LICENSE
       src/*.zig
 deps:
-  mattnite/network: ^0.0.6
+  network:
+    git:
+      url: "https://github.com/MasterQ32/zig-network.git"
+      ref: master
+      root: network.zig
   mattnite/uri: ^0.0.1
   truemedian/hzzp: ^0.1.8
   iguanaTLS:


### PR DESCRIPTION
The latest commit on https://github.com/MasterQ32/zig-network fixes the c_void break in zig 0.9. I am suppppeerr new to zig and am not sure if this is the right way to track master in gyro.